### PR TITLE
possible openstore crash fix

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -28,6 +28,6 @@ cp $ROOT/codium.desktop $pkgdir/
 cp $ROOT/codium.wrapper $pkgdir/
 chmod a+x $pkgdir/codium.wrapper
 chown root $pkgdir/chrome-sandbox
-chmod 4755 ./chrome-sandbox
+chmod 4755 $pkgdir/chrome-sandbox
 
 exit 0

--- a/build.sh
+++ b/build.sh
@@ -27,5 +27,7 @@ cp $ROOT/codium.apparmor $pkgdir/
 cp $ROOT/codium.desktop $pkgdir/
 cp $ROOT/codium.wrapper $pkgdir/
 chmod a+x $pkgdir/codium.wrapper
+chown root $pkgdir/chrome-sandbox
+chmod 4755 ./chrome-sandbox
 
 exit 0


### PR DESCRIPTION
Ubuntu Touch version of VS Codium (installed via [OpenStore](https://open-store.io/app/codium.vscodium.com) crashes instantly when trying to open. (device: Nexus 7)

When attempting to run the `codium` executable I got this message:

```
[25836:0309/223950.347654:FATAL:setuid_sandbox_host.cc(158)] The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now. You need to make sure that /opt/click.ubuntu.com/codium.vscodium.com/1.65.0/chrome-sandbox is owned by root and has mode 4755.
Bus error
```
same goes with `codium.wrapper`...

running
```
chown root /opt/click.ubuntu.com/codium.vscodium.com/1.65.0/chrome-sandbox
chmod 4755 /opt/click.ubuntu.com/codium.vscodium.com/1.65.0/chrome-sandbox
```

resolved this issue for me and the app now opens properly.
