### PR TITLE
Fixed "error: Libtool library used but 'LIBTOOL' is undefined"

### DIFF
--- a/clickable.json
+++ b/clickable.json
@@ -19,7 +19,8 @@
     "libwayland-dev",
     "libxi-dev",
     "python3-pip",
-    "wget"
+    "wget",
+    "libtool"
   ],
   "dependencies_target": [
     "libasound2",


### PR DESCRIPTION
@fredldotme couldn't build on debian 12 for ubuntu touch 20.04.
This commit helped.